### PR TITLE
make legacy data downloadable, closes #82

### DIFF
--- a/R/gdcdata.R
+++ b/R/gdcdata.R
@@ -28,6 +28,9 @@
 #'     to restricted data. See
 #'     \url{https://gdc-docs.nci.nih.gov/API/Users_Guide/Authentication_and_Authorization/}.
 #'
+#' @param ... further arguments passed to files, particulary useful when
+#'     requesting \code{legacy=TRUE}
+#'
 #' @seealso \code{\link{manifest}} for downloading large data.
 #'
 #' @return a named vector with file uuids as the names and paths as
@@ -49,19 +52,27 @@
 #'     ids()
 #'
 #' # and get the data, placing it into the gdc_cache() directory
-#' fpaths <- gdcdata(uuids, use_cached=TRUE)
-#' 
-#' fpaths
+#' gdcdata(uuids, use_cached=TRUE)
+#'
+#' # legacy data
+#' exon <- files(legacy = TRUE) %>%
+#'     filter( ~ cases.project.project_id == "TCGA-COAD" &
+#'         data_category == "Gene expression" &
+#'         data_type == "Exon quantification") %>%
+#'     results(size = 1) %>% ids()
+#'
+#' gdcdata(exon, legacy = TRUE)
+#'
 #' @export
 gdcdata <-
     function(uuids, use_cached=TRUE,
              progress=interactive(), token=NULL, access_method='api',
-             transfer_args = character())
+             transfer_args = character(), ...)
 {
     stopifnot(is.character(uuids))
 
     uuids = trimws(uuids)
-    manifest = files() %>%
+    manifest = files(...) %>%
             GenomicDataCommons::filter( ~ file_id %in% uuids ) %>%
             GenomicDataCommons::manifest()
     # files from previous downloads should have the following

--- a/man/gdcdata.Rd
+++ b/man/gdcdata.Rd
@@ -27,6 +27,9 @@ to restricted data. See
 \item{transfer_args}{character(1), additional arguments to pass to
 the gdc-client command line. See \code{\link{gdc_client}} and
 \code{\link{transfer_help}} for details.}
+
+\item{...}{further arguments passed to files, particulary useful when
+requesting \code{legacy=TRUE}}
 }
 \value{
 a named vector with file uuids as the names and paths as
@@ -57,9 +60,17 @@ uuids <- files() \%>\%
     ids()
 
 # and get the data, placing it into the gdc_cache() directory
-fpaths <- gdcdata(uuids, use_cached=TRUE)
+gdcdata(uuids, use_cached=TRUE)
 
-fpaths
+# legacy data
+exon <- files(legacy = TRUE) \%>\%
+    filter( ~ cases.project.project_id == "TCGA-COAD" &
+        data_category == "Gene expression" &
+        data_type == "Exon quantification") \%>\%
+    results(size = 1) \%>\% ids()
+
+gdcdata(exon, legacy = TRUE)
+
 }
 \seealso{
 \code{\link{manifest}} for downloading large data.


### PR DESCRIPTION
Hi Sean, @seandavi 

This makes it possible to download legacy data. This is related to #82. 
I decided to add an ellipses argument `...` but if you'd like I can use a
`legacy` argument instead. 

Thanks!